### PR TITLE
Fix notifications styling

### DIFF
--- a/src/components/Notification.module.css
+++ b/src/components/Notification.module.css
@@ -42,18 +42,18 @@
   flex-direction: column-reverse;
 }
 
-.notification-topRight > span > div,
-.notification-bottomRight > span > div {
+.notification-topRight > div > div,
+.notification-bottomRight > div > div {
   animation: notification-right-in 200ms ease-in 1;
 }
 
-.notification-topLeft > span > div,
-.notification-bottomLeft > span > div {
+.notification-topLeft > div > div,
+.notification-bottomLeft > div > div {
   animation: notification-left-in 200ms ease-in 1;
 }
 
 /* Styles the notice */
-.root > span > div {
+.root > div > div {
   background: #fff;
   padding: 12px 16px;
   border-radius: 4px;


### PR DESCRIPTION
The `rc-notification` module changed a `span` tag to a `div` tag when showing notifications. Due to this, notifications were not being styled correctly.